### PR TITLE
ZUBA-358 Podman Tweaks

### DIFF
--- a/.docker/.env-template
+++ b/.docker/.env-template
@@ -1,26 +1,29 @@
-# ENVs include recommended default values for local development
-# Remove these values if changing them in the .env file
+# Copy all keys into a .env file in the same directory as this file.
+# The .env is used to set environment variables for the Docker containers.
+# Leave these values blank to use the defaults from the compose.controller.yaml file.
+# Do not remove blank keys or the defaults will not work with Podman.
 
-# Necessary ENVs
+# No defaults for these keys, so you must set them.
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 S3_ACCESS_KEY=
 S3_SECRET_ACCESS_KEY=
 S3_ENDPOINT_URL=
 
-# ENVs that define compose.controller.yaml defaults
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=root
-POSTGRES_DB=ai_db
-POSTGRES_PORT=5432
+# These keys have default values.
+TRULENS_USER=
+TRULENS_PASSWORD=
+TRULENS_DB=
+TRULENS_PORT=
 
-TRULENS_USER=postgres
-TRULENS_PASSWORD=root
-TRULENS_DB=trulens
-TRULENS_PORT=5432
+NEO4J_USER=
+NEO4J_PASSWORD=
+NEO4J_DB=
+NEO4J_PORT=
+NEO4J_DASHBOARD_PORT=
 
-NEO4J_USER=neo4j
-NEO4J_PASSWORD=12345678
-NEO4J_DB=bc_laws
-NEO4J_PORT=7687
-NEO4J_DASHBOARD_PORT=7474
+# For Postgres container used in early examples
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+POSTGRES_DB=
+POSTGRES_PORT=

--- a/.docker/.env-template
+++ b/.docker/.env-template
@@ -1,3 +1,6 @@
+# ENVs include recommended default values for local development
+# Remove these values if changing them in the .env file
+
 # Necessary ENVs
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
@@ -5,19 +8,19 @@ S3_ACCESS_KEY=
 S3_SECRET_ACCESS_KEY=
 S3_ENDPOINT_URL=
 
-# ENVs that overwrite docker-compose defaults
-# Do not recommend setting in local environment
-POSTGRES_USER=
-POSTGRES_PASSWORD=
-POSTGRES_DB=
-POSTGRES_PORT=
+# ENVs that define compose.controller.yaml defaults
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=root
+POSTGRES_DB=ai_db
+POSTGRES_PORT=5432
 
-TRULENS_USER=
-TRULENS_PASSWORD=
-TRULENS_DB=
-TRULENS_PORT=
+TRULENS_USER=postgres
+TRULENS_PASSWORD=root
+TRULENS_DB=trulens
+TRULENS_PORT=5432
 
-NEO4J_USER=
-NEO4J_PASSWORD=
-NEO4J_DB=
-NEO4J_PORT=
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=12345678
+NEO4J_DB=bc_laws
+NEO4J_PORT=7687
+NEO4J_DASHBOARD_PORT=7474

--- a/.docker/compose.controller.yaml
+++ b/.docker/compose.controller.yaml
@@ -8,13 +8,13 @@ services:
     image: pgvector/pgvector:0.6.1-pg16
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-root}
-      POSTGRES_DB: ${POSTGRES_DB:-ai_db}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "${POSTGRES_PORT}:5432"
     healthcheck:
       test:
         [
@@ -34,20 +34,20 @@ services:
       dockerfile: ../examples/Dockerfile
     platform: linux/amd64
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-root}
-      POSTGRES_DB: ${POSTGRES_DB:-ai_db}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_HOST: postgres
-      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
-      TRULENS_USER: ${TRULENS_USER:-postgres}
-      TRULENS_PASSWORD: ${TRULENS_PASSWORD:-root}
-      TRULENS_DB: ${TRULENS_DB:-trulens}
-      TRULENS_PORT: ${TRULENS_PORT:-5432}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      TRULENS_USER: ${TRULENS_USER}
+      TRULENS_PASSWORD: ${TRULENS_PASSWORD}
+      TRULENS_DB: ${TRULENS_DB}
+      TRULENS_PORT: ${TRULENS_PORT}
       TRULENS_HOST: trulens
-      NEO4J_USER: ${NEO4J_USER:-neo4j}
-      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-12345678}
-      NEO4J_DB: ${NEO4J_DB:-bclaws}
-      NEO4J_PORT: ${NEO4J_PORT:-7687}
+      NEO4J_USER: ${NEO4J_USER}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+      NEO4J_DB: ${NEO4J_DB}
+      NEO4J_PORT: ${NEO4J_PORT}
       NEO4J_HOST: neo4j
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
@@ -128,12 +128,11 @@ services:
     environment:
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@airflow_postgres/airflow
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
-      NEO4J_USERNAME: ${NEO4J_USER:-neo4j}
-      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-12345678}
-      NEO4J_DB: ${NEO4J_DB:-neo4j}
-      NEO4J_PORT: ${NEO4J_PORT:-7687}
+      NEO4J_USERNAME: ${NEO4J_USER}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+      NEO4J_DB: ${NEO4J_DB}
+      NEO4J_PORT: ${NEO4J_PORT}
       NEO4J_HOST: neo4j
-      NEO4J_URI: ${NEO4J_URI}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
       S3_ENDPOINT_URL: ${S3_ENDPOINT_URL}
@@ -171,13 +170,13 @@ services:
     image: postgres:16.2
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${TRULENS_USER:-postgres}
-      POSTGRES_PASSWORD: ${TRULENS_PASSWORD:-root}
-      POSTGRES_DB: ${TRULENS_DB:-trulens}
+      POSTGRES_USER: ${TRULENS_USER}
+      POSTGRES_PASSWORD: ${TRULENS_PASSWORD}
+      POSTGRES_DB: ${TRULENS_DB}
     volumes:
       - trulensdata:/var/lib/postgresql/data
     ports:
-      - "${POSTGRES_PORT:-5433}:5432"
+      - "5433:${TRULENS_PORT}"
     healthcheck:
       test:
         [
@@ -196,18 +195,18 @@ services:
     image: neo4j:latest
     restart: unless-stopped
     environment:
-      - USERNAME=${NEO4J_USER:-neo4j}
-      - PASSWORD=${NEO4J_PASSWORD:-12345678}
-      - DB=${NEO4J_DB:-bclaws}
+      - USERNAME=${NEO4J_USER}
+      - PASSWORD=${NEO4J_PASSWORD}
+      - DB=${NEO4J_DB}
       - NEO4J_AUTH=none
-      - NEO4JLABS_PLUGINS=["apoc", "graph-data-science"]
       - NEO4J_PLUGINS=["apoc", "graph-data-science"]
+      - NEO4J_server_config_strict__validation_enabled=false
     volumes:
       - neo4j:/var/lib/neo4j/data
       - neo4j-backup:/var/lib/neo4j/backups
     ports:
-      - "${NEO4J_PORT:-7474}:7474"
-      - "${NEO4J_PORT:-7687}:7687"
+      - "${NEO4J_DASHBOARD_PORT}:7474"
+      - "${NEO4J_PORT}:7687"
     healthcheck:
       test:
         ["CMD-SHELL", "pg_isready -d $${NEO4J_DB} -U $${NEO4J_USER} || exit 1"]
@@ -224,6 +223,8 @@ services:
       context: ../web/frontend
       dockerfile: Dockerfile
       target: prod
+    depends_on:
+      - web_backend
     ports:
       - "8080:8080"
     networks:
@@ -249,18 +250,20 @@ services:
       context: ../web/backend-fastapi
       dockerfile: Dockerfile
     environment:
-      TRULENS_USER: ${TRULENS_USER:-postgres}
-      TRULENS_PASSWORD: ${TRULENS_PASSWORD:-root}
-      TRULENS_DB: ${TRULENS_DB:-trulens}
-      TRULENS_PORT: ${TRULENS_PORT:-5432}
+      TRULENS_USER: ${TRULENS_USER}
+      TRULENS_PASSWORD: ${TRULENS_PASSWORD}
+      TRULENS_DB: ${TRULENS_DB}
+      TRULENS_PORT: ${TRULENS_PORT}
       TRULENS_HOST: trulens
-      NEO4J_USERNAME: ${NEO4J_USER:-neo4j}
-      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-12345678}
-      NEO4J_VECTOR_INDEX: ${NEO4J_VECTOR_INDEX:-Acts_Updatedchunks}
-      NEO4J_DB: ${NEO4J_DB:-neo4j}
-      NEO4J_PORT: ${NEO4J_PORT:-7687}
+      NEO4J_USERNAME: ${NEO4J_USER}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+      NEO4J_DB: ${NEO4J_DB}
+      NEO4J_PORT: ${NEO4J_PORT}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+    depends_on:
+      - trulens
+      - neo4j
     ports:
       - "10000:10000"
     volumes:
@@ -276,10 +279,10 @@ services:
       context: ../web/trulens-dashboard
       dockerfile: Dockerfile
     environment:
-      TRULENS_USER: ${TRULENS_USER:-postgres}
-      TRULENS_PASSWORD: ${TRULENS_PASSWORD:-root}
-      TRULENS_DB: ${TRULENS_DB:-postgres}
-      TRULENS_PORT: ${TRULENS_PORT:-5432}
+      TRULENS_USER: ${TRULENS_USER}
+      TRULENS_PASSWORD: ${TRULENS_PASSWORD}
+      TRULENS_DB: ${TRULENS_DB}
+      TRULENS_PORT: ${TRULENS_PORT}
       TRULENS_HOST: trulens
     ports:
       - "14000:14000"

--- a/.docker/compose.controller.yaml
+++ b/.docker/compose.controller.yaml
@@ -199,7 +199,6 @@ services:
       - PASSWORD=${NEO4J_PASSWORD:-12345678}
       - DB=${NEO4J_DB:-bclaws}
       - NEO4J_AUTH=none
-      - NEO4JLABS_PLUGINS=["apoc", "graph-data-science"]
       - NEO4J_PLUGINS=["apoc", "graph-data-science"]
       - NEO4J_server_config_strict__validation_enabled=false
     volumes:

--- a/.docker/compose.controller.yaml
+++ b/.docker/compose.controller.yaml
@@ -8,13 +8,13 @@ services:
     image: pgvector/pgvector:0.6.1-pg16
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-root}
+      POSTGRES_DB: ${POSTGRES_DB:-ai_db}
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
-      - "${POSTGRES_PORT}:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     healthcheck:
       test:
         [
@@ -34,20 +34,20 @@ services:
       dockerfile: ../examples/Dockerfile
     platform: linux/amd64
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-root}
+      POSTGRES_DB: ${POSTGRES_DB:-ai_db}
       POSTGRES_HOST: postgres
-      POSTGRES_PORT: ${POSTGRES_PORT}
-      TRULENS_USER: ${TRULENS_USER}
-      TRULENS_PASSWORD: ${TRULENS_PASSWORD}
-      TRULENS_DB: ${TRULENS_DB}
-      TRULENS_PORT: ${TRULENS_PORT}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      TRULENS_USER: ${TRULENS_USER:-postgres}
+      TRULENS_PASSWORD: ${TRULENS_PASSWORD:-root}
+      TRULENS_DB: ${TRULENS_DB:-trulens}
+      TRULENS_PORT: ${TRULENS_PORT:-5432}
       TRULENS_HOST: trulens
-      NEO4J_USER: ${NEO4J_USER}
-      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
-      NEO4J_DB: ${NEO4J_DB}
-      NEO4J_PORT: ${NEO4J_PORT}
+      NEO4J_USER: ${NEO4J_USER:-neo4j}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-12345678}
+      NEO4J_DB: ${NEO4J_DB:-bclaws}
+      NEO4J_PORT: ${NEO4J_PORT:-7687}
       NEO4J_HOST: neo4j
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
@@ -128,10 +128,10 @@ services:
     environment:
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@airflow_postgres/airflow
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
-      NEO4J_USERNAME: ${NEO4J_USER}
-      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
-      NEO4J_DB: ${NEO4J_DB}
-      NEO4J_PORT: ${NEO4J_PORT}
+      NEO4J_USERNAME: ${NEO4J_USER:-neo4j}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-12345678}
+      NEO4J_DB: ${NEO4J_DB:-neo4j}
+      NEO4J_PORT: ${NEO4J_PORT:-7687}
       NEO4J_HOST: neo4j
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
@@ -170,13 +170,13 @@ services:
     image: postgres:16.2
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${TRULENS_USER}
-      POSTGRES_PASSWORD: ${TRULENS_PASSWORD}
-      POSTGRES_DB: ${TRULENS_DB}
+      POSTGRES_USER: ${TRULENS_USER:-postgres}
+      POSTGRES_PASSWORD: ${TRULENS_PASSWORD:-root}
+      POSTGRES_DB: ${TRULENS_DB:-trulens}
     volumes:
       - trulensdata:/var/lib/postgresql/data
     ports:
-      - "5433:${TRULENS_PORT}"
+      - "5433:${TRULENS_PORT:-5432}"
     healthcheck:
       test:
         [
@@ -195,18 +195,19 @@ services:
     image: neo4j:latest
     restart: unless-stopped
     environment:
-      - USERNAME=${NEO4J_USER}
-      - PASSWORD=${NEO4J_PASSWORD}
-      - DB=${NEO4J_DB}
+      - USERNAME=${NEO4J_USER:-neo4j}
+      - PASSWORD=${NEO4J_PASSWORD:-12345678}
+      - DB=${NEO4J_DB:-bclaws}
       - NEO4J_AUTH=none
+      - NEO4JLABS_PLUGINS=["apoc", "graph-data-science"]
       - NEO4J_PLUGINS=["apoc", "graph-data-science"]
       - NEO4J_server_config_strict__validation_enabled=false
     volumes:
       - neo4j:/var/lib/neo4j/data
       - neo4j-backup:/var/lib/neo4j/backups
     ports:
-      - "${NEO4J_DASHBOARD_PORT}:7474"
-      - "${NEO4J_PORT}:7687"
+      - "${NEO4J_DASHBOARD_PORT:-7474}:7474"
+      - "${NEO4J_PORT:-7687}:7687"
     healthcheck:
       test:
         ["CMD-SHELL", "pg_isready -d $${NEO4J_DB} -U $${NEO4J_USER} || exit 1"]
@@ -250,15 +251,15 @@ services:
       context: ../web/backend-fastapi
       dockerfile: Dockerfile
     environment:
-      TRULENS_USER: ${TRULENS_USER}
-      TRULENS_PASSWORD: ${TRULENS_PASSWORD}
-      TRULENS_DB: ${TRULENS_DB}
-      TRULENS_PORT: ${TRULENS_PORT}
+      TRULENS_USER: ${TRULENS_USER:-postgres}
+      TRULENS_PASSWORD: ${TRULENS_PASSWORD:-root}
+      TRULENS_DB: ${TRULENS_DB:-trulens}
+      TRULENS_PORT: ${TRULENS_PORT:-5432}
       TRULENS_HOST: trulens
-      NEO4J_USERNAME: ${NEO4J_USER}
-      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
-      NEO4J_DB: ${NEO4J_DB}
-      NEO4J_PORT: ${NEO4J_PORT}
+      NEO4J_USERNAME: ${NEO4J_USER:-neo4j}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-12345678}
+      NEO4J_DB: ${NEO4J_DB:-neo4j}
+      NEO4J_PORT: ${NEO4J_PORT:-7687}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     depends_on:
@@ -279,10 +280,10 @@ services:
       context: ../web/trulens-dashboard
       dockerfile: Dockerfile
     environment:
-      TRULENS_USER: ${TRULENS_USER}
-      TRULENS_PASSWORD: ${TRULENS_PASSWORD}
-      TRULENS_DB: ${TRULENS_DB}
-      TRULENS_PORT: ${TRULENS_PORT}
+      TRULENS_USER: ${TRULENS_USER:-postgres}
+      TRULENS_PASSWORD: ${TRULENS_PASSWORD:-root}
+      TRULENS_DB: ${TRULENS_DB:-trulens}
+      TRULENS_PORT: ${TRULENS_PORT:-5432}
       TRULENS_HOST: trulens
     ports:
       - "14000:14000"


### PR DESCRIPTION
<!--
PR Title format:
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->
[ZUBA-358](https://citz-imb.atlassian.net/jira/software/c/projects/ZUBA/boards/62?selectedIssue=ZUBA-358)
Mostly a ticket to address the limitations of Podman as we move away from Docker.

## Changes
- Default environment variables aren't handled in the compose file. To help with this, I've updated the `.env-template` file to include those default values that were previously there.
- Made it so the frontend relies on the backend, which relies on trulens and neo4j. They shouldn't start out of order now.

## Testing
Populate your `.env` file before testing.
Would be good to test this on Mac and Windows.
If you need help getting Podman set up, reach out. It was fairly painless.
Removing Docker will also potentially remove your volumes. Be prepared to restore Neo4j data.

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->


## 🔰 Checklist

- [x] I have read and agree with the following checklist

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
