### PR TITLE
ZUBA-340 Follow Up

### DIFF
--- a/web/frontend/src/pages/Home/Sidebar/Sidebar.tsx
+++ b/web/frontend/src/pages/Home/Sidebar/Sidebar.tsx
@@ -153,7 +153,7 @@ const Sidebar = () => {
           title='Options'
           description={
             <>
-              <h2>Select RAG State</h2>
+              <h2>Search & Query Version</h2>
               {activeStates.length ? (
                 activeStates.map((state) => (
                   <div className='rag-state-option' key={state.key}>

--- a/web/frontend/src/pages/Home/Sidebar/Sidebar.tsx
+++ b/web/frontend/src/pages/Home/Sidebar/Sidebar.tsx
@@ -50,28 +50,30 @@ const Sidebar = () => {
   // Load the RAG states from the API
   useEffect(() => {
     getChatStates()
-      .then((data) => setActiveStates(data))
-      .catch((e) => console.warn(`Active RAG states not found: ${e}`));
-    if (activeStates.length) {
-      const setDefaultState = () => {
-        context.setChatState(activeStates.at(0)!);
-        setSelectedState(activeStates.at(0)!.key);
-        sessionStorage.setItem('ragStateKey', activeStates.at(0)!.key);
-      };
-      if (!defaultState) {
-        setDefaultState();
-      } else {
-        const foundState = activeStates.find(
-          (state) => state.key === defaultState,
-        );
-        if (foundState) {
-          context.setChatState(foundState);
-          setSelectedState(foundState.key);
-        } else {
-          setDefaultState();
+      .then((data) => {
+        setActiveStates(data);
+        if (data.length) {
+          const setDefaultState = () => {
+            context.setChatState(data.at(0)!);
+            setSelectedState(data.at(0)!.key);
+            sessionStorage.setItem('ragStateKey', data.at(0)!.key);
+          };
+          if (!defaultState) {
+            setDefaultState();
+          } else {
+            const foundState = data.find((state) => state.key === defaultState);
+            if (foundState) {
+              context.setChatState(foundState);
+              setSelectedState(foundState.key);
+            } else {
+              setDefaultState();
+            }
+          }
         }
-      }
-    }
+
+        return data;
+      })
+      .catch((e) => console.warn(`Active RAG states not found: ${e}`));
   }, []);
 
   // Function to toggle sidebar


### PR DESCRIPTION
<!--
PR Title format:
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->
[ZUBA-340](https://citz-imb.atlassian.net/jira/software/c/projects/ZUBA/boards/62?selectedIssue=ZUBA-340)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
Fixes an issue where no frontend state was potentially set for users arriving to the page. It wasn't getting set because the state wasn't populated when this block of code was checking for `activeStates.length`. 
There wouldn't be an error, but there would be no radio button checked initially. 

Now, the v2UpdatedChunks option should be checked by default if no previous state was chosen.

## Changes
- Moved initial state set code inside the `.then` of the API call. Should now properly set a default if no key in sessionStorage exists.
- Changed `Select RAG Version` to `Search & Query Version` in the options modal. Hoping this will be more comprehensible for the average user.

## Testing
- Delete the ragState key in your session storage, then reload the page.
- When the `/states` route finishes loading, it should set a key and opening the options modal should show v2UpdatedChunks selected.

## 🔰 Checklist

- [x] I have read and agree with the following checklist

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
