### PR TITLE
ZUBA-364 Reinstate Reranker

### DIFF
--- a/web/backend-fastapi/app/models/neo4j.py
+++ b/web/backend-fastapi/app/models/neo4j.py
@@ -2,7 +2,9 @@ from langchain_community.graphs import Neo4jGraph
 import os
 
 
-def neo4j_vector_search(kg, question, embeddings, vector_index, vector_search_query):
+def neo4j_vector_search(
+    kg, question, embeddings, vector_index, vector_search_query, top_k=10
+):
     """Search for similar nodes using the Neo4j vector index"""
     query_embedding = embeddings.embed_query(question)
     similar = kg.query(
@@ -10,7 +12,7 @@ def neo4j_vector_search(kg, question, embeddings, vector_index, vector_search_qu
         params={
             "question": query_embedding,
             "index_name": vector_index,
-            "top_k": 10,
+            "top_k": top_k,
         },
     )
     return similar

--- a/web/backend-fastapi/app/models/rag.py
+++ b/web/backend-fastapi/app/models/rag.py
@@ -102,16 +102,14 @@ class get_full_rag:
     def query(self, query: str, chat_history: List[ChatHistory], kg, state) -> str:
         query_with_history = self.query_with_history(query, chat_history)
         context_str = self.retrieve(query_with_history, kg, state)
+        context_str = self.re_rank_reference(
+            context_str,
+            query,
+            [
+                {"name": "text", "weight": 1}
+            ],  # Use text field which exists in both schemas
+        )
         create_prompt = self.create_prompt(query, context_str, chat_history, state)
         bedrock_response = self.get_response(create_prompt, state.kwargs_key)
-        # Rerank to sort references by relevance to response
-        #context_str = self.re_rank_reference(
-        #    context_str,
-        #    bedrock_response,
-        #    [
-        #        {"name": "text", "weight": 1}
-        #    ],  # Use text field which exists in both schemas
-        #)
-
         pretty_output = self.formatoutput(context_str, bedrock_response)
         return json.dumps(pretty_output)

--- a/web/backend-fastapi/app/models/rag.py
+++ b/web/backend-fastapi/app/models/rag.py
@@ -62,7 +62,11 @@ class get_full_rag:
 
     @instrument
     def re_rank_reference(
-        self, topk, compared_text, doc_fields=[{"name": "text", "weight": 1}]
+        self,
+        topk,
+        compared_text,
+        doc_fields=[{"name": "text", "weight": 1}],
+        take_top=5,
     ):
         model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
         for field in doc_fields:
@@ -89,7 +93,7 @@ class get_full_rag:
             key=lambda x: x.get("cross_score", 0),
             reverse=True,
         )
-        return topk
+        return topk.copy()[:take_top]  # Return top k results
 
     def query_with_history(self, query: str, chat_history: List[ChatHistory]):
         query_with_history = ""
@@ -105,9 +109,6 @@ class get_full_rag:
         context_str = self.re_rank_reference(
             context_str,
             query,
-            [
-                {"name": "text", "weight": 1}
-            ],  # Use text field which exists in both schemas
         )
         create_prompt = self.create_prompt(query, context_str, chat_history, state)
         bedrock_response = self.get_response(create_prompt, state.kwargs_key)

--- a/web/backend-fastapi/app/models/rag_states/State.py
+++ b/web/backend-fastapi/app/models/rag_states/State.py
@@ -16,13 +16,14 @@ class State(ABC):
     An abtract class used as the base for all RAG states.
     """
 
-    def __init__(self, tag, version, index, query, kwargs_key, description):
+    def __init__(self, tag, version, index, query, kwargs_key, description, top_k=10):
         self.__tag = tag
         self.__version = version
         self.__vector_index = index
         self.__vector_query = query
         self.__kwargs_key = kwargs_key
         self.__description = description
+        self.__top_k = top_k
 
     @property
     def tag(self):
@@ -51,6 +52,10 @@ class State(ABC):
     @property
     def type(self):
         return StateType.INTERNAL
+
+    @property
+    def top_k(self):
+        return self.__top_k
 
     @abstractmethod
     def create_prompt(self, context_str, question, chat_history): ...

--- a/web/backend-fastapi/app/models/rag_states/v2_UpdatedChunks.py
+++ b/web/backend-fastapi/app/models/rag_states/v2_UpdatedChunks.py
@@ -38,6 +38,7 @@ class UpdatedChunks(State):
             query=self.__vector_search_query,
             kwargs_key="mixtral",
             description=self.__description,
+            top_k=10,
         )
 
     def create_prompt(
@@ -77,4 +78,5 @@ class UpdatedChunks(State):
             self.__embeddings,
             self.__vector_index,
             self.__vector_search_query,
+            self.top_k,
         )

--- a/web/backend-fastapi/app/models/rag_states/v3_AtomicIndexing.py
+++ b/web/backend-fastapi/app/models/rag_states/v3_AtomicIndexing.py
@@ -45,6 +45,7 @@ class AtomicIndexing(State):
             query=self.__vector_search_query,
             kwargs_key="mixtral",
             description=self.__description,
+            top_k=10,
         )
 
     def create_prompt(
@@ -109,4 +110,5 @@ class AtomicIndexing(State):
             self.__embeddings,
             self.__vector_index,
             self.__vector_search_query,
+            self.top_k,
         )

--- a/web/backend-fastapi/app/models/rag_states/v3_AtomicIndexing.py
+++ b/web/backend-fastapi/app/models/rag_states/v3_AtomicIndexing.py
@@ -8,7 +8,7 @@ from ...common.chat_objects import ChatHistory
 
 class AtomicIndexing(State):
     __tag = "v3AtomicIndexing"  # Don't update this
-    __version = "1"  # Update this if making changes
+    __version = "2"  # Update this if making changes
     __description = """
       Structure of data indexing reflects the structure of the Acts and Regulations.
       Uses UpdatedChunks for initial search, then returns all context of matched Sections.
@@ -20,7 +20,7 @@ class AtomicIndexing(State):
         OPTIONAL MATCH (node)-[:IS]-(atomicSection)
         OPTIONAL MATCH (atomicSection)-[:CONTAINS*]->(containedNode)
         OPTIONAL MATCH (containedNode)-[:NEXT*]->(nextNode)
-        OPTIONAL MATCH (containedNode)-[:REFERENCE]->(refNode)
+        OPTIONAL MATCH (containedNode)-[:REFERENCES_v3]->(refNode)
         RETURN score, 
               node.ActId AS ActId,  
               node.RegId as Regulations, 

--- a/web/backend-fastapi/app/models/rag_states/v4_ImagesAndChunks.py
+++ b/web/backend-fastapi/app/models/rag_states/v4_ImagesAndChunks.py
@@ -46,6 +46,7 @@ class ImagesAndChunks(State):
             query=self.__vector_search_query,
             kwargs_key="mixtral",
             description=self.__description,
+            top_k=10,
         )
 
     def create_prompt(
@@ -85,4 +86,5 @@ class ImagesAndChunks(State):
             self.__embeddings,
             self.__vector_index,
             self.__vector_search_query,
+            self.top_k,
         )

--- a/web/backend-fastapi/main.py
+++ b/web/backend-fastapi/main.py
@@ -1,4 +1,16 @@
 import sys
+from sentence_transformers import CrossEncoder
+from langchain_community.embeddings import HuggingFaceEmbeddings
+
+
+# Preload the model at application startup
+# They are stored in cache allowing for faster lookup later
+def preload_models():
+    CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
+    HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+
+
+preload_models()
 
 
 class MockNestAsyncio:


### PR DESCRIPTION
<!--
PR Title format:
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->
[ZUBA-364](https://citz-imb.atlassian.net/jira/software/c/projects/ZUBA/boards/62?selectedIssue=ZUBA-364)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
## Changes
- Separated topk value into their respective states. We can tweak this value for each RAG states separately now. This only affects the neo4j retrieval.
- Uncommented the reranking function in the rag model, but placed it prior to the LLM request. It cuts down the number of topk to 5 post sort, but this can be overridden through arguments.
- Added function in main that preloads models. They are placed in the ~/.cache.... folder in the container, so you'll see the startup process take a little longer, but then the models will be ready to go immediately when called.
- Fixed the reference tag with the atomic indexing state query to match the other work. If you have these edges created in your database, they will now be used here as well.

## Testing
- Run queries with a few different states.
- Run the ETL to transform the trulens data and view that table to see the latencies for each part

I didn't see much of a response quality difference between 5, 10, or 20 items pulled from neo4j. Trimming it down to 5 after the re-ranker didn't seem to affect quality much either. 

There is a difference in the speed of the re-ranker depending on how many items you pass to it. I had about 0.6-0.7 seconds with 5 items and 0.8-1.0 with the full 10 items.
The fewer items sent to the LLM also makes a time difference. AtomicIndexing is much slower at this step because it still involves a lot more connected context from the neo4j matches.

## 🔰 Checklist

- [x] I have read and agree with the following checklist

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
